### PR TITLE
zodでGPTの出力の型を指定

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
         "": {
             "name": "my-schedule",
             "version": "0.1.0",
+            "hasInstallScript": true,
             "dependencies": {
                 "@emotion/cache": "^11.14.0",
                 "@emotion/react": "^11.14.0",
@@ -35,6 +36,7 @@
                 "lottie-react": "^2.4.1",
                 "next": "15.0.4",
                 "openai": "^4.86.2",
+                "prisma": "^6.3.1",
                 "react": "^19.0.0",
                 "react-confetti": "^6.4.0",
                 "react-dom": "^19.0.0",
@@ -44,7 +46,8 @@
                 "react-router-dom": "^7.1.1",
                 "react-spinners": "^0.15.0",
                 "server-only": "^0.0.1",
-                "styled-components": "^6.1.15"
+                "styled-components": "^6.1.15",
+                "zod": "^3.25.76"
             },
             "devDependencies": {
                 "@types/node": "^20",
@@ -55,7 +58,6 @@
                 "eslint-config-prettier": "^10.1.1",
                 "postcss": "^8",
                 "prettier": "^3.6.2",
-                "prisma": "^6.3.1",
                 "supabase": "^2.19.7",
                 "tailwindcss": "^3.4.1",
                 "typescript": "^5"
@@ -1954,7 +1956,6 @@
             "version": "6.17.1",
             "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.17.1.tgz",
             "integrity": "sha512-fs8wY6DsvOCzuiyWVckrVs1LOcbY4LZNz8ki4uUIQ28jCCzojTGqdLhN2Jl5lDnC1yI8/gNIKpsWDM8pLhOdwA==",
-            "devOptional": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "c12": "3.1.0",
@@ -1967,14 +1968,12 @@
             "version": "6.17.1",
             "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.17.1.tgz",
             "integrity": "sha512-Vf7Tt5Wh9XcndpbmeotuqOMLWPTjEKCsgojxXP2oxE1/xYe7PtnP76hsouG9vis6fctX+TxgmwxTuYi/+xc7dQ==",
-            "devOptional": true,
             "license": "Apache-2.0"
         },
         "node_modules/@prisma/engines": {
             "version": "6.17.1",
             "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.17.1.tgz",
             "integrity": "sha512-D95Ik3GYZkqZ8lSR4EyFOJ/tR33FcYRP8kK61o+WMsyD10UfJwd7+YielflHfKwiGodcqKqoraWw8ElAgMDbPw==",
-            "devOptional": true,
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -1988,14 +1987,12 @@
             "version": "6.17.1-1.272a37d34178c2894197e17273bf937f25acdeac",
             "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.17.1-1.272a37d34178c2894197e17273bf937f25acdeac.tgz",
             "integrity": "sha512-17140E3huOuD9lMdJ9+SF/juOf3WR3sTJMVyyenzqUPbuH+89nPhSWcrY+Mf7tmSs6HvaO+7S+HkELinn6bhdg==",
-            "devOptional": true,
             "license": "Apache-2.0"
         },
         "node_modules/@prisma/fetch-engine": {
             "version": "6.17.1",
             "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.17.1.tgz",
             "integrity": "sha512-AYZiHOs184qkDMiTeshyJCtyL4yERkjfTkJiSJdYuSfc24m94lTNL5+GFinZ6vVz+ktX4NJzHKn1zIFzGTWrWg==",
-            "devOptional": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@prisma/debug": "6.17.1",
@@ -2007,7 +2004,6 @@
             "version": "6.17.1",
             "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.17.1.tgz",
             "integrity": "sha512-AKEn6fsfz0r482S5KRDFlIGEaq9wLNcgalD1adL+fPcFFblIKs1sD81kY/utrHdqKuVC6E1XSRpegDK3ZLL4Qg==",
-            "devOptional": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@prisma/debug": "6.17.1"
@@ -2103,7 +2099,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
             "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
-            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/@stitches/core": {
@@ -3449,7 +3444,6 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/c12/-/c12-3.1.0.tgz",
             "integrity": "sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==",
-            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "chokidar": "^4.0.3",
@@ -3592,7 +3586,6 @@
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
             "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "readdirp": "^4.0.1"
@@ -3618,7 +3611,6 @@
             "version": "0.1.6",
             "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
             "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
-            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "consola": "^3.2.3"
@@ -3727,14 +3719,12 @@
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
             "integrity": "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==",
-            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/consola": {
             "version": "3.4.2",
             "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
             "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
-            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": "^14.18.0 || >=16.10.0"
@@ -4056,7 +4046,6 @@
             "version": "7.1.5",
             "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
             "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
-            "devOptional": true,
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=16.0.0"
@@ -4102,7 +4091,6 @@
             "version": "6.1.4",
             "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
             "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
-            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/delayed-stream": {
@@ -4118,7 +4106,6 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
             "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
-            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/detect-libc": {
@@ -4172,7 +4159,6 @@
             "version": "16.6.1",
             "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
             "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-            "devOptional": true,
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=12"
@@ -4206,7 +4192,6 @@
             "version": "3.16.12",
             "resolved": "https://registry.npmjs.org/effect/-/effect-3.16.12.tgz",
             "integrity": "sha512-N39iBk0K71F9nb442TLbTkjl24FLUzuvx2i1I2RsEAQsdAdUTuUoW0vlfUXgkMTUOnYqKnWcFfqw4hK4Pw27hg==",
-            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@standard-schema/spec": "^1.0.0",
@@ -4224,7 +4209,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz",
             "integrity": "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==",
-            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=14"
@@ -4907,14 +4891,12 @@
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.7.tgz",
             "integrity": "sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==",
-            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/fast-check": {
             "version": "3.23.2",
             "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
             "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
-            "devOptional": true,
             "funding": [
                 {
                     "type": "individual",
@@ -5324,7 +5306,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/giget/-/giget-2.0.0.tgz",
             "integrity": "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==",
-            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "citty": "^0.1.6",
@@ -6134,7 +6115,6 @@
             "version": "2.6.1",
             "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
             "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-            "devOptional": true,
             "license": "MIT",
             "bin": {
                 "jiti": "lib/jiti-cli.mjs"
@@ -6642,7 +6622,6 @@
             "version": "1.6.7",
             "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
             "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
-            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/normalize-path": {
@@ -6669,7 +6648,6 @@
             "version": "0.6.2",
             "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.2.tgz",
             "integrity": "sha512-7eM+hpOtrKrBDCh7Ypu2lJ9Z7PNZBdi/8AT3AX8xoCj43BBVHD0hPSTEvMtkMpfs8FCqBGhxB+uToIQimA111g==",
-            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "citty": "^0.1.6",
@@ -6821,7 +6799,6 @@
             "version": "2.0.11",
             "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
             "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
-            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/once": {
@@ -7050,14 +7027,12 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
             "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/perfect-debounce": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
             "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
-            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/picocolors": {
@@ -7103,7 +7078,6 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
             "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
-            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "confbox": "^0.2.2",
@@ -7280,7 +7254,6 @@
             "version": "6.17.1",
             "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.17.1.tgz",
             "integrity": "sha512-ac6h0sM1Tg3zu8NInY+qhP/S9KhENVaw9n1BrGKQVFu05JT5yT5Qqqmb8tMRIE3ZXvVj4xcRA5yfrsy4X7Yy5g==",
-            "devOptional": true,
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -7343,7 +7316,6 @@
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
             "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
-            "devOptional": true,
             "funding": [
                 {
                     "type": "individual",
@@ -7381,7 +7353,6 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
             "integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
-            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "defu": "^6.1.4",
@@ -7577,7 +7548,6 @@
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
             "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 14.18.0"
@@ -8802,7 +8772,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.1.tgz",
             "integrity": "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==",
-            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/tinyglobby": {
@@ -9446,6 +9415,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/zod": {
+            "version": "3.25.76",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
         "react-router-dom": "^7.1.1",
         "react-spinners": "^0.15.0",
         "server-only": "^0.0.1",
-        "styled-components": "^6.1.15"
+        "styled-components": "^6.1.15",
+        "zod": "^3.25.76"
     },
     "devDependencies": {
         "@types/node": "^20",


### PR DESCRIPTION
zodでGPTの出力の型を指定、必ずjsonデータになるようにする

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Validates and parses the ChatGPT recommend output with a Zod schema via OpenAI’s zodResponseFormat, returning structured JSON; adds zod dependency.
> 
> - **Backend (app/api/chatgpt/route.ts)**
>   - **Recommend flow**:
>     - Define Zod schema for todo objects and array (`title`, `description`, `startdate`, `enddate`, `interval`, `tag`).
>     - Use `response_format: zodResponseFormat(todosArrayType, "recommendedTodos")` to enforce structured output.
>     - Return `data.choices[0]?.message?.parsed` instead of raw `content`.
> - **Dependencies**:
>   - Add `zod` to `package.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9dcf7d17e49e40cceed4fb5726ac1308ced67cb4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->